### PR TITLE
Feature/markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "rails-i18n", "~> 6.0.0"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.4", require: false
 gem "redcarpet"
+gem "coderay"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "rails-i18n", "~> 6.0.0"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.4", require: false
+gem "redcarpet"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
+  coderay
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -201,6 +202,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.0)
   rails-i18n (~> 6.0.0)
+  redcarpet
   sass-rails (>= 6)
   spring
   turbolinks (~> 5)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,3 +25,6 @@ div.field_with_errors {
     border: 2px solid red;
   }
 }
+.header{
+  text-align: center;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,18 +1,4 @@
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, or any plugin's
- * vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
- *
- *= require_tree .
- *= require_self
- */
+
  @import "bootstrap/scss/bootstrap";
 
  $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
@@ -27,4 +13,18 @@ div.field_with_errors {
 }
 .header{
   text-align: center;
+}
+pre{
+  border: 2px dashed rgb(213, 213, 244);
+  background-color: rgb(236, 236, 250);
+}
+.content{
+  max-width: 1000px;
+  margin: 0px auto;
+}
+.title{
+  border-bottom: 2px solid rgb(198, 191, 191);
+}
+code{
+  background-color: rgb(245, 210, 216);
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   before_action :set_post, only: %i[show edit update destroy]
   def index
-    @posts = Post.order(id: :asc)
+    @posts = Post.order(id: :DESC)
   end
 
   def show

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,27 @@
+module MarkdownHelper
+  def markdown(text)
+    markdown = Redcarpet::Markdown.new(html_renderer, markdown_extensions)
+    markdown.render(text).html_safe
+  end
+
+  private
+
+  def html_renderer
+    Redcarpet::Render::HTML
+  end
+
+  def markdown_extensions
+    # 設定の詳細は https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use
+    {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true
+    }
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -8,6 +8,11 @@ module MarkdownHelper
 
   def html_renderer
     Redcarpet::Render::HTML
+    ::Coderayify.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: 'nofollow', target: "_blank" }
+    )
   end
 
   def markdown_extensions

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,4 @@
 class Post < ApplicationRecord
   validates :title, presence: true, length: { maximum: 50 }
-  validates :content, presence: true, length: { maximum: 500 }
+  validates :content, presence: true, length: { maximum: 100000 }
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,2 +1,4 @@
-<%= link_to "投稿一覧", posts_path %> <%= link_to "新規投稿", new_post_path %>
-<hr>
+<div class="header">
+  <%= link_to "投稿一覧", posts_path %> <%= link_to "新規投稿", new_post_path %>
+  <hr>
+</div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,12 +1,12 @@
 <%= render "layouts/error_messages" %>
 <%= form_with model: @post, local: true do |form| %>
   <div>
-    <%= form.label :title %>
-    <%= form.text_field :title %>
+    <p><%= form.label :title %></p>
+    <p><%= form.text_field :title %></p>
   </div>
   <div>
-    <%= form.label :content %>
-    <%= form.text_field :content, size: "100px" %>
+    <p><%= form.label :content %></p>
+    <p><%= form.text_area :content, size: "100px" %></p>
   </div>
   <div>
     <%= form.submit button_value %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,3 +2,9 @@
 <h2>参照画面</h2>
 <p>タイトル：<%= @post.title %></p>
 <p>詳細：<%= @post.content %></p>
+<div>
+  <% renderer = Redcarpet::Render::HTML %>
+  <% extensions = { tables: true } %>
+  <% markdown = Redcarpet::Markdown.new(renderer, extensions) %>
+  <%= markdown.render(@post.content).html_safe %>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,9 @@
+
+<div class="content">
 <%= render "date" %>
-<h2>参照画面</h2>
-<p>タイトル：<%= @post.title %></p>
-<p>詳細：<%= @post.content %></p>
-<div>
-  <%= markdown(@post.content) %>
+  <div>
+  <h3 class="title"><%= @post.title %></h3>
+  <div class=>
+    <%= markdown(@post.content) %>
+  </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,8 +3,5 @@
 <p>タイトル：<%= @post.title %></p>
 <p>詳細：<%= @post.content %></p>
 <div>
-  <% renderer = Redcarpet::Render::HTML %>
-  <% extensions = { tables: true } %>
-  <% markdown = Redcarpet::Markdown.new(renderer, extensions) %>
-  <%= markdown.render(@post.content).html_safe %>
+  <%= markdown(@post.content) %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module DailyReportApp
     config.time_zone = 'Asia/Tokyo'
     config.i18n.default_locale = :ja
     # Configuration for the application, engines, and railties goes here.
-    #
+    config.autoload_paths << Rails.root.join("lib/autoloads")
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #

--- a/lib/autoloads/coderayify.rb
+++ b/lib/autoloads/coderayify.rb
@@ -1,0 +1,34 @@
+class Coderayify < Redcarpet::Render::HTML
+  def block_code(code, language)
+    # コードブロックの拡張子を取得
+    ext = retrieve_extension(language)
+    # 適用するシンタックスハイライトの言語を決める
+    lang = case ext
+           when "rb"
+             :ruby
+           when "yml"
+             :yaml
+           else
+             ext.to_sym
+           end
+    CodeRay.scan(code, lang).div
+  end
+
+  private
+
+  # 拡張子を取得するメソッド
+  def retrieve_extension(language)
+    if language.blank?
+      # コードブロックの開始宣言で「```」の後に拡張子が与えられていない場合は md 形式とみなす
+      "md"
+    elsif language.include?(":")
+      # コードブロックの開始宣言が「```rb:sample.rb」の場合は rb 形式とみなす
+      language.split(':')[0]
+    elsif language.include?(".")
+      # コードブロックの開始宣言が「```sample.rb」の場合は rb 形式とみなす
+      language.split('.')[-1]
+    else
+      language
+    end
+  end
+end


### PR DESCRIPTION
## 実装内容

-投稿画面
  - 一覧画面の投稿を降順に設定
  - スタイルを綺麗にする
  - ボタンスタイルを入れる
- 参照画面
  - 真ん中に寄せる
  - コードブロックのとき背景とボーダーが適用されるようにスタイルを設定
  - インラインコードのとき背景を染めるように設定

## 参考資料

- [公式−redcarpet](https://github.com/vmg/redcarpet)
- [やんばるコード-CSS基礎（その2）](https://arcane-gorge-21903.herokuapp.com/texts/258)
- [やんばるコード-マークダウン ](https://arcane-gorge-21903.herokuapp.com/texts/224)

## 苦労したこと

- テキストフィールド内でエンターを利用できるようにしたこと→form.fieldからform.text_area
- cssのボーダーラインを表示させること→ボーダーラインの種類を指定すること
- マークダウンを導入すること→テキスト教材を見ることで解決したが、中身は理解していない
- コードブロック、インラインコードにCSSを割り当てること→実行後ブラウザの検証ツールを使ってクラスや、タグを特定。その後そのクラスまたはタグにCSSを割り当てる


